### PR TITLE
schema: extract enum types into  (1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the bh-audit-schema project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-05-12
+
+### Changed
+
+- Refactored `ActionType`, `OutcomeStatus`, and `DataClassification` from inline
+  `enum` arrays into named `$defs` with `$ref` usage. Enum values are identical.
+  Enables downstream consumers to derive allowlists from a single source of truth.
+  Closes bh-healthcare/bh-audit-schema#5.
+
 ## [1.1.1] - 2026-03-11
 
 ### Added
@@ -65,6 +74,7 @@ See [docs/controls-mapping.md](docs/controls-mapping.md) for detailed HIPAA Secu
 - Documentation: field definitions, event types, privacy model, controls mapping, query examples, rationale, versioning.
 - Examples: patient read, login, note update failure, patient data export.
 
+[1.1.2]: https://github.com/bh-healthcare/bh-audit-schema/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/bh-healthcare/bh-audit-schema/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/bh-healthcare/bh-audit-schema/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/bh-healthcare/bh-audit-schema/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This repository defines a standardized schema for audit events in behavioral hea
 
 | Path | Description |
 |------|-------------|
-| [`schema/audit_event.schema.json`](schema/audit_event.schema.json) | Latest stable schema |
+| [`schema/audit_event.schema.json`](schema/audit_event.schema.json) | Latest stable schema (currently **v1.1.2**) |
+| [`schema/versions/1.1/`](schema/versions/1.1/) | Immutable v1.1.x schema (latest: 1.1.2) |
 | [`schema/versions/1.0/`](schema/versions/1.0/) | Immutable v1.0 schema |
 
 ### Example Event
@@ -67,6 +68,15 @@ Audit events capture **what happened**, not **the content** of what was accessed
 ### Strict Validation
 
 The schema uses `additionalProperties: false` at all levels (except `metadata`) to ensure events conform exactly to the specification.
+
+### Single Source of Truth for Enums
+
+As of **v1.1.2**, the canonical enum types — `ActionType`, `OutcomeStatus`, and
+`DataClassification` — live as named definitions under `$defs` and are referenced
+via `$ref` from `action.type`, `outcome.status`, and `action.data_classification`.
+The accepted values are unchanged. This lets downstream consumers
+(`bh-fastapi-audit`, `bh-audit-logger`, custom validators) derive their allowlists
+from a single, machine-readable source instead of duplicating the enum arrays.
 
 ### Implementation Flexibility
 

--- a/docs/field-definitions.md
+++ b/docs/field-definitions.md
@@ -100,6 +100,10 @@ Describes what action was performed.
 
 ### `action.type` Enum
 
+Defined in `$defs/ActionType` and referenced via `$ref: "#/$defs/ActionType"`.
+Downstream consumers can derive type-safe allowlists from the single source of
+truth in `$defs`.
+
 | Value    | Use Case                                              |
 |----------|-------------------------------------------------------|
 | `READ`   | Retrieving or viewing data                            |
@@ -115,7 +119,7 @@ Describes what action was performed.
 ### `phi_touched` and `data_classification`
 
 - **`phi_touched`**: Boolean flag indicating whether the action actually accessed or modified Protected Health Information under HIPAA/42 CFR Part 2.
-- **`data_classification`**: Classification of what the *resource contains*, regardless of whether it was actually accessed.
+- **`data_classification`**: Classification of what the *resource contains*, regardless of whether it was actually accessed. Defined in `$defs/DataClassification` and referenced via `$ref: "#/$defs/DataClassification"`.
 
 **On DENIED events:** Set `phi_touched: false` because PHI was not actually accessed (the request was blocked). Set `data_classification` to reflect what the resource contains (e.g., `"PHI"`), not what the actor saw. This distinction matters for compliance: the resource is PHI, but no PHI was disclosed.
 
@@ -182,6 +186,9 @@ Describes the result of the action.
 | `error_message` | string | Conditional | maxLength: 500           | Sanitized error message                           |
 
 ### Status Values (v1.1)
+
+`outcome.status` is defined in `$defs/OutcomeStatus` and referenced via
+`$ref: "#/$defs/OutcomeStatus"`.
 
 | Status    | Meaning                                        | `error_type`    | `error_message` |
 |-----------|------------------------------------------------|-----------------|-----------------|

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -137,7 +137,8 @@ Schema changes follow this process:
 
 | Version | Release Date | Status       | Notes                                                        |
 |---------|--------------|--------------|--------------------------------------------------------------|
-| 1.1     | 2026-03-11   | Current      | Hardening: UUID enforcement, DENIED status, metadata scalars |
+| 1.1.2   | 2026-05-12   | Current      | Enum `$defs` refactor (structural, no value changes)         |
+| 1.1     | 2026-03-11   | Supported    | Hardening: UUID enforcement, DENIED status, metadata scalars |
 | 1.0     | 2026-01-06   | Supported    | Initial release                                              |
 
 ---

--- a/schema/audit_event.schema.json
+++ b/schema/audit_event.schema.json
@@ -4,6 +4,23 @@
   "title": "BH Audit Event",
   "type": "object",
   "additionalProperties": false,
+  "$defs": {
+    "ActionType": {
+      "type": "string",
+      "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"],
+      "description": "Canonical action taxonomy for BH audit events."
+    },
+    "OutcomeStatus": {
+      "type": "string",
+      "enum": ["SUCCESS", "FAILURE", "DENIED"],
+      "description": "Terminal outcome classification for an audited action."
+    },
+    "DataClassification": {
+      "type": "string",
+      "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+      "description": "Regulatory classification of the data touched by the action."
+    }
+  },
   "required": [
     "schema_version",
     "event_id",
@@ -88,10 +105,7 @@
       "additionalProperties": false,
       "required": ["type"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"]
-        },
+        "type": { "$ref": "#/$defs/ActionType" },
         "name": {
           "type": "string",
           "maxLength": 128,
@@ -102,8 +116,7 @@
           "description": "True if the action touches regulated PHI (behavioral health context)."
         },
         "data_classification": {
-          "type": "string",
-          "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+          "$ref": "#/$defs/DataClassification",
           "default": "UNKNOWN"
         }
       }
@@ -147,7 +160,7 @@
       "additionalProperties": false,
       "required": ["status"],
       "properties": {
-        "status": { "type": "string", "enum": ["SUCCESS", "FAILURE", "DENIED"] },
+        "status": { "$ref": "#/$defs/OutcomeStatus" },
         "error_type": { "type": "string", "minLength": 1, "maxLength": 128 },
         "error_message": {
           "type": "string",

--- a/schema/versions/1.1/CHANGELOG.md
+++ b/schema/versions/1.1/CHANGELOG.md
@@ -6,6 +6,15 @@ This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ---
 
+## [1.1.2] -- 2026-05-12
+
+### Changed
+
+- `action.type`, `outcome.status`, and `action.data_classification` enums extracted
+  into named `$defs` (`ActionType`, `OutcomeStatus`, `DataClassification`) and
+  referenced via `$ref`. Enum values are unchanged; this is a structural refactor
+  to enable downstream consumers to derive allowlists from a single source of truth.
+
 ## [1.1.0] -- 2026-03-11
 
 ### Added

--- a/schema/versions/1.1/audit_event.schema.json
+++ b/schema/versions/1.1/audit_event.schema.json
@@ -4,6 +4,23 @@
   "title": "BH Audit Event",
   "type": "object",
   "additionalProperties": false,
+  "$defs": {
+    "ActionType": {
+      "type": "string",
+      "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"],
+      "description": "Canonical action taxonomy for BH audit events."
+    },
+    "OutcomeStatus": {
+      "type": "string",
+      "enum": ["SUCCESS", "FAILURE", "DENIED"],
+      "description": "Terminal outcome classification for an audited action."
+    },
+    "DataClassification": {
+      "type": "string",
+      "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+      "description": "Regulatory classification of the data touched by the action."
+    }
+  },
   "required": [
     "schema_version",
     "event_id",
@@ -88,10 +105,7 @@
       "additionalProperties": false,
       "required": ["type"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"]
-        },
+        "type": { "$ref": "#/$defs/ActionType" },
         "name": {
           "type": "string",
           "maxLength": 128,
@@ -102,8 +116,7 @@
           "description": "True if the action touches regulated PHI (behavioral health context)."
         },
         "data_classification": {
-          "type": "string",
-          "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+          "$ref": "#/$defs/DataClassification",
           "default": "UNKNOWN"
         }
       }
@@ -147,7 +160,7 @@
       "additionalProperties": false,
       "required": ["status"],
       "properties": {
-        "status": { "type": "string", "enum": ["SUCCESS", "FAILURE", "DENIED"] },
+        "status": { "$ref": "#/$defs/OutcomeStatus" },
         "error_type": { "type": "string", "minLength": 1, "maxLength": 128 },
         "error_message": {
           "type": "string",

--- a/tests/test_defs_structure.py
+++ b/tests/test_defs_structure.py
@@ -1,0 +1,75 @@
+"""Verify v1.1 schema publishes enums as named $defs referenced via $ref."""
+
+import json
+from pathlib import Path
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "schema"
+    / "versions"
+    / "1.1"
+    / "audit_event.schema.json"
+)
+ROOT_PATH = (
+    Path(__file__).resolve().parent.parent / "schema" / "audit_event.schema.json"
+)
+
+
+def _load():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+class TestDefsExist:
+    def test_defs_key_present(self):
+        assert "$defs" in _load()
+
+    def test_action_type_def(self):
+        defn = _load()["$defs"]["ActionType"]
+        assert defn["type"] == "string"
+        assert set(defn["enum"]) == {
+            "READ",
+            "CREATE",
+            "UPDATE",
+            "DELETE",
+            "EXPORT",
+            "LOGIN",
+            "LOGOUT",
+            "PRINT",
+            "OTHER",
+        }
+
+    def test_outcome_status_def(self):
+        defn = _load()["$defs"]["OutcomeStatus"]
+        assert defn["type"] == "string"
+        assert set(defn["enum"]) == {"SUCCESS", "FAILURE", "DENIED"}
+
+    def test_data_classification_def(self):
+        defn = _load()["$defs"]["DataClassification"]
+        assert defn["type"] == "string"
+        assert set(defn["enum"]) == {"PHI", "PII", "NONE", "UNKNOWN"}
+
+
+class TestRefsUsed:
+    def test_action_type_ref(self):
+        prop = _load()["properties"]["action"]["properties"]["type"]
+        assert prop.get("$ref") == "#/$defs/ActionType"
+
+    def test_outcome_status_ref(self):
+        prop = _load()["properties"]["outcome"]["properties"]["status"]
+        assert prop.get("$ref") == "#/$defs/OutcomeStatus"
+
+    def test_data_classification_ref(self):
+        prop = _load()["properties"]["action"]["properties"]["data_classification"]
+        assert prop.get("$ref") == "#/$defs/DataClassification"
+
+
+class TestFileSync:
+    def test_root_matches_versioned(self):
+        with open(ROOT_PATH) as f:
+            root = f.read()
+        with open(SCHEMA_PATH) as f:
+            versioned = f.read()
+        assert root == versioned, (
+            "Root schema must be byte-for-byte copy of latest versioned schema"
+        )


### PR DESCRIPTION
## [1.1.2] - 2026-05-12

### Changed

- Refactored `ActionType`, `OutcomeStatus`, and `DataClassification` from inline
  `enum` arrays into named `$defs` with `$ref` usage. Enum values are identical.
  Enables downstream consumers to derive allowlists from a single source of truth.
  Closes bh-healthcare/bh-audit-schema#5.